### PR TITLE
Allow edge-to-edge calendar in split view

### DIFF
--- a/src/components/EmotionalCalendar.tsx
+++ b/src/components/EmotionalCalendar.tsx
@@ -13,6 +13,8 @@ const CalendarContainer = styled.div`
   background: #1a1a1a;
   color: #fff;
   position: relative;
+  border-radius: 32px;
+  overflow: hidden;
 `;
 
 const CalendarWrapper = styled.div`

--- a/src/components/VerticalSplit/VerticalSplit.tsx
+++ b/src/components/VerticalSplit/VerticalSplit.tsx
@@ -194,7 +194,7 @@ const BottomPanel = styled(Panel)<{ $top: number; $scale?: number }>`
   top: ${props => props.$top}px;
 `;
 
-const ContentContainer = styled.div`
+const ContentContainer = styled.div<{ $padding?: number }>`
   height: 100%;
   width: 100%;
   display: flex;
@@ -203,7 +203,7 @@ const ContentContainer = styled.div`
   position: relative;
   box-sizing: border-box;
   border-radius: 32px;
-  padding: 16px;
+  padding: ${props => props.$padding ?? 16}px;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.2) rgba(255, 255, 255, 0.05);
   
@@ -658,7 +658,7 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
         $backgroundColor={effectiveBgColor}
         $scale={topScale}
       >
-        <ContentContainer>
+        <ContentContainer $padding={0}>
           {effectiveTop}
           {topViewOverlay}
         </ContentContainer>


### PR DESCRIPTION
## Summary
- Make `ContentContainer` padding configurable and remove it for the top panel so the calendar spans edge-to-edge
- Round and clip `CalendarContainer` to match the top panel

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a91be2f9348327bc52f9dee92d5dac