### PR TITLE
fix: improve divider drag handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,7 +286,7 @@ function ThemedApp() {
     }
   ];
 
-  const menuItems = [
+  const menuAccessories = [
     { label: 'Add New Event', icon: '➕', onClick: handleAddEvent },
     { label: 'Edit Mode', icon: '✏️', onClick: handleEditMode },
     { label: 'Clear All Events', icon: '🗑️', onClick: handleClearEvents },
@@ -300,7 +300,7 @@ function ThemedApp() {
       <VerticalSplit
         leadingAccessories={leadingAccessories}
         trailingAccessories={trailingAccessories}
-        menuItems={menuItems}
+        menuAccessories={menuAccessories}
       >
         <Panel>
           {showSettings ? (

--- a/src/components/VerticalSplit/VerticalSplit.tsx
+++ b/src/components/VerticalSplit/VerticalSplit.tsx
@@ -270,6 +270,7 @@ const Divider = ({
   menuAccessories,
   menuIcon,
   menuColor,
+  isDragging,
 }: {
   top: number;
   onMouseDown: (e: React.MouseEvent) => void;
@@ -279,6 +280,7 @@ const Divider = ({
   menuAccessories?: MenuAccessory[];
   menuIcon?: React.ReactNode;
   menuColor?: string;
+  isDragging: boolean;
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -316,7 +318,7 @@ const Divider = ({
         alignItems: 'center',
         justifyContent: 'center',
         cursor: 'grab',
-        transition: 'top 0.25s ease',
+        transition: isDragging ? 'none' : 'top 0.25s ease',
       }}
     >
       <div style={{
@@ -480,6 +482,7 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
   const [splitY, setSplitY] = useState<number>(0);
   const [containerHeight, setContainerHeight] = useState<number>(0);
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
+  const [isDragging, setIsDragging] = useState(false);
 
   // Derive content from explicit props or children
   const childrenArray = React.Children.toArray(children);
@@ -552,6 +555,8 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+
+    setIsDragging(true);
     
     // Set grabbing cursor on the entire document during drag
     document.body.style.cursor = 'grabbing';
@@ -605,6 +610,7 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
       snapToEdge();
+      setIsDragging(false);
 
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
@@ -618,6 +624,8 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
   const handleTouchStart = (e: React.TouchEvent) => {
     e.preventDefault();
     e.stopPropagation();
+
+    setIsDragging(true);
     
     const startY = e.touches[0].clientY;
     const startSplitY = splitY;
@@ -664,6 +672,7 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
     
     const onTouchEnd = () => {
       snapToEdge();
+      setIsDragging(false);
       document.removeEventListener('touchmove', onTouchMove as any);
       document.removeEventListener('touchend', onTouchEnd as any);
     };
@@ -709,6 +718,7 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
         top={splitY - DIVIDER_HEIGHT / 2}
         onMouseDown={handleMouseDown}
         onTouchStart={handleTouchStart}
+        isDragging={isDragging}
         leadingAccessories={leadingAccessories}
         trailingAccessories={trailingAccessories}
         menuAccessories={effectiveMenu}

--- a/src/components/VerticalSplit/VerticalSplit.tsx
+++ b/src/components/VerticalSplit/VerticalSplit.tsx
@@ -451,7 +451,6 @@ interface VerticalSplitProps {
   leadingAccessories?: SplitAccessory[];
   trailingAccessories?: SplitAccessory[];
   menuAccessories?: MenuAccessory[];
-  menuItems?: MenuAccessory[];
   menuIcon?: React.ReactNode;
   menuColor?: string;
   children?: React.ReactNode;
@@ -470,7 +469,6 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
   leadingAccessories,
   trailingAccessories,
   menuAccessories,
-  menuItems,
   menuIcon,
   menuColor,
   children,
@@ -488,7 +486,6 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
   const childrenArray = React.Children.toArray(children);
   const effectiveTop = topView ?? childrenArray[0] ?? null;
   const effectiveBottom = bottomView ?? childrenArray[1] ?? null;
-  const effectiveMenu = menuItems ?? menuAccessories;
 
   // Initialize container height and split position
   useEffect(() => {
@@ -721,7 +718,7 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
         isDragging={isDragging}
         leadingAccessories={leadingAccessories}
         trailingAccessories={trailingAccessories}
-        menuAccessories={effectiveMenu}
+        menuAccessories={menuAccessories}
         menuIcon={menuIcon}
         menuColor={menuColor}
       />


### PR DESCRIPTION
## Summary
- track divider dragging with isDragging flag
- remove divider transition while dragging
- restore transition for programmatic snaps

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a932be0b208327a2d577c7a0d3a8b5