### PR TITLE
refactor: remove unused menuItems prop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,7 +286,7 @@ function ThemedApp() {
     }
   ];
 
-  const menuItems = [
+  const menuAccessories = [
     { label: 'Add New Event', icon: '➕', onClick: handleAddEvent },
     { label: 'Edit Mode', icon: '✏️', onClick: handleEditMode },
     { label: 'Clear All Events', icon: '🗑️', onClick: handleClearEvents },
@@ -300,7 +300,7 @@ function ThemedApp() {
       <VerticalSplit
         leadingAccessories={leadingAccessories}
         trailingAccessories={trailingAccessories}
-        menuItems={menuItems}
+        menuAccessories={menuAccessories}
       >
         <Panel>
           {showSettings ? (

--- a/src/components/VerticalSplit/VerticalSplit.tsx
+++ b/src/components/VerticalSplit/VerticalSplit.tsx
@@ -449,7 +449,6 @@ interface VerticalSplitProps {
   leadingAccessories?: SplitAccessory[];
   trailingAccessories?: SplitAccessory[];
   menuAccessories?: MenuAccessory[];
-  menuItems?: MenuAccessory[];
   menuIcon?: React.ReactNode;
   menuColor?: string;
   children?: React.ReactNode;
@@ -468,7 +467,6 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
   leadingAccessories,
   trailingAccessories,
   menuAccessories,
-  menuItems,
   menuIcon,
   menuColor,
   children,
@@ -485,7 +483,6 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
   const childrenArray = React.Children.toArray(children);
   const effectiveTop = topView ?? childrenArray[0] ?? null;
   const effectiveBottom = bottomView ?? childrenArray[1] ?? null;
-  const effectiveMenu = menuItems ?? menuAccessories;
 
   // Initialize container height and split position
   useEffect(() => {
@@ -711,7 +708,7 @@ const VerticalSplit: React.FC<VerticalSplitProps> = ({
         onTouchStart={handleTouchStart}
         leadingAccessories={leadingAccessories}
         trailingAccessories={trailingAccessories}
-        menuAccessories={effectiveMenu}
+        menuAccessories={menuAccessories}
         menuIcon={menuIcon}
         menuColor={menuColor}
       />


### PR DESCRIPTION
## Summary
- remove redundant menuItems prop from VerticalSplit and use menuAccessories only
- update App to pass menuAccessories to VerticalSplit

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a932ce7c588327a5d1d4d766528a47