### PR TITLE
refactor: centralize VerticalSplit border radius

### DIFF
--- a/src/components/VerticalSplit/VerticalSplit.tsx
+++ b/src/components/VerticalSplit/VerticalSplit.tsx
@@ -4,6 +4,7 @@ import { scaleDownButtonStyle, vibrate, getPanelScale } from './utils';
 import { useTheme } from '../../contexts/ThemeContext';
 
 // Constants
+const BORDER_RADIUS = 32;
 const DIVIDER_HEIGHT = 20;
 const ACCESSORY_SIZE = 24;
 const ACCESSORY_SPACING = 8;
@@ -44,7 +45,7 @@ const Container = styled.div<{ $backgroundColor: string }>`
   height: 100%;
   display: flex;
   flex-direction: column;
-  border-radius: 32px;
+  border-radius: ${BORDER_RADIUS}px;
 `;
 
 const HomeIndicatorHandle = styled.div`
@@ -201,7 +202,6 @@ const Panel = styled.div<{ $height: number; $backgroundColor: string; $scale?: n
   width: 100%;
   height: ${props => props.$height}px;
   background: ${props => props.$backgroundColor};
-  border-radius: 32px;
   overflow: hidden;
   box-sizing: border-box;
   transform: scale(${props => props.$scale || 1});
@@ -226,7 +226,6 @@ const ContentContainer = styled.div`
   overflow: auto;
   position: relative;
   box-sizing: border-box;
-  border-radius: 32px;
   padding: 16px;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.2) rgba(255, 255, 255, 0.05);


### PR DESCRIPTION
## Summary
- consolidate border radius in VerticalSplit via shared constant
- apply border radius only on outer Container and remove inner panel redundancies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a932c5553483279078f656bbfe6f56