### PR TITLE
Stabilize emoji select callback and call on drag end

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, lazy, useEffect } from 'react';
+import { useState, useRef, lazy, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import VerticalSplit from './components/VerticalSplit/VerticalSplit';
 import {
@@ -22,6 +22,7 @@ const DataExport = lazy(() => import('./components/DataExport'));
 const SettingsPage = lazy(() => import('./components/SettingsPage'));
 import { ThemeProvider, useTheme } from './contexts/ThemeContext';
 import { EventData } from './types/event-data';
+import { EmotionLog } from './types/emotion-log';
 import './index.css';
 import './styles/emotional-calendar.css';
 
@@ -226,6 +227,10 @@ function ThemedApp() {
     dataExportRef.current?.handleExportCSV();
   };
 
+  const handleEmojiSelect = useCallback((data: EmotionLog) => {
+    console.log('Emoji selected', data);
+  }, []);
+
   const leadingAccessories = [
     {
       icon: <CalendarDaysIcon />,
@@ -337,7 +342,7 @@ function ThemedApp() {
           )}
         </Panel>
         <Panel>
-          <EmojiGridMapper />
+          <EmojiGridMapper onEmojiSelect={handleEmojiSelect} />
         </Panel>
       </VerticalSplit>
       <DataExport ref={dataExportRef} events={events} enableToasts={notificationsEnabled} />

--- a/src/components/EmojiGridMapper/EmojiGridMapper.tsx
+++ b/src/components/EmojiGridMapper/EmojiGridMapper.tsx
@@ -31,6 +31,7 @@ const EmojiGridMapper: React.FC<EmojiGridMapperProps> = ({ onEmojiSelect }) => {
   const circleRef = useRef<HTMLDivElement>(null);
   const backgroundRef = useRef<HTMLDivElement>(null);
   const vfxRef = useRef<VFX | null>(null);
+  const lastPositionRef = useRef({ x: 0, y: 0 });
 
   // Get emoji based on position
   const getEmoji = useCallback((x: number, y: number) => {
@@ -165,6 +166,7 @@ const EmojiGridMapper: React.FC<EmojiGridMapperProps> = ({ onEmojiSelect }) => {
         const unitX = this.x / radius;
         const unitY = -this.y / radius; // Flip Y for screen coordinates
         setPosition({ x: unitX, y: unitY });
+        lastPositionRef.current = { x: unitX, y: unitY };
 
         // Update background VFX effects based on position
         const intensity = Math.sqrt(unitX * unitX + unitY * unitY);
@@ -180,7 +182,11 @@ const EmojiGridMapper: React.FC<EmojiGridMapperProps> = ({ onEmojiSelect }) => {
           });
         }
 
-        // Callback with current emoji
+      },
+      onDragEnd: function() {
+        setIsDragging(false);
+
+        const { x: unitX, y: unitY } = lastPositionRef.current;
         const currentEmoji = getEmoji(unitX, unitY);
         const emotion = getEmotionLabel(unitX, unitY);
         onEmojiSelect?.({
@@ -191,15 +197,12 @@ const EmojiGridMapper: React.FC<EmojiGridMapperProps> = ({ onEmojiSelect }) => {
           arousal: unitY,
           timestamp: new Date().toISOString()
         });
-      },
-      onDragEnd: function() {
-        setIsDragging(false);
-        
+
         // Remove VFX effects when drag ends
         if (vfxRef.current && backgroundRef.current) {
           vfxRef.current.remove(backgroundRef.current);
         }
-        
+
         // Snap back to center with enhanced animation
         gsap.to(this.target, {
           x: 0,

--- a/src/components/EmojiGridMapper/__tests__/EmojiGridMapper.test.tsx
+++ b/src/components/EmojiGridMapper/__tests__/EmojiGridMapper.test.tsx
@@ -8,7 +8,8 @@ jest.mock('gsap', () => ({
   __esModule: true,
   default: {
     set: jest.fn(),
-    registerPlugin: jest.fn()
+    registerPlugin: jest.fn(),
+    to: jest.fn()
   }
 }));
 jest.mock('gsap/Draggable', () => ({
@@ -35,6 +36,7 @@ test('onEmojiSelect includes timestamp', () => {
 
   act(() => {
     opts.onDrag.call({ x: 0, y: 0 });
+    opts.onDragEnd.call({});
   });
 
   expect(onEmojiSelect).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- memoize emoji select handler in App with useCallback
- trigger onEmojiSelect once at drag end using a stored position
- adjust tests for drag-end selection

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aa792fa5108327abe6cf22595dc3e0