### PR TITLE
Restore export quick action card

### DIFF
--- a/src/components/N8NDashboard.tsx
+++ b/src/components/N8NDashboard.tsx
@@ -215,6 +215,9 @@ const N8NDashboard: React.FC = () => {
       case 'patterns':
         n8nService.triggerPatternDetection(mockEvents);
         break;
+      case 'export':
+        // Export is handled by the N8NDataExport component
+        break;
     }
   };
 
@@ -260,6 +263,12 @@ const N8NDashboard: React.FC = () => {
           <ActionIcon>🔍</ActionIcon>
           <ActionTitle>Detect Patterns</ActionTitle>
           <ActionDescription>Analyze emotional trends</ActionDescription>
+        </ActionCard>
+
+        <ActionCard className="glass-card" onClick={() => handleQuickAction('export')}>
+          <ActionIcon>📊</ActionIcon>
+          <ActionTitle>Export Data</ActionTitle>
+          <ActionDescription>Send data in various formats</ActionDescription>
         </ActionCard>
       </QuickActions>
 


### PR DESCRIPTION
## Summary
- revive the Export Data quick action in the N8N dashboard
- handle export action in quick action switch to keep component logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac0cb02f7c83279e2442548236969b